### PR TITLE
clean up arguments panel and deselect previous button when an immediate_run button is clicked

### DIFF
--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 4, 0)
+VERSION = (0, 4, 1)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/view.py
+++ b/src/gui_executor/view.py
@@ -1028,6 +1028,19 @@ class View(QMainWindow):
 
         if button.immediate_run():
             self.run_function(button.function, [], {}, RUNNABLE_SCRIPT)
+
+            # Remove any existing arguments panel from a previous button
+
+            if self._args_panel:
+                self._args_panel.hide()
+                self._args_panel = None
+
+            # Deselect the previously selected button
+
+            if self.previous_selected_button is not None:
+                self.previous_selected_button.deselect()
+                self.previous_selected_button = None
+
             return
 
         # TODO


### PR DESCRIPTION
When an immediate_run button is pressed, any arguments panel and selected button from a previous run is now cleaned up.