### PR TITLE
immediate run buttons and Enum type hints

### DIFF
--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 4, 1)
+VERSION = (0, 4, 2)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 4, 3)
+VERSION = (0, 4, 4)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 5, 1)
+VERSION = (0, 6, 0)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 4, 2)
+VERSION = (0, 4, 3)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 6, 1)
+VERSION = (0, 6, 2)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 4, 5)
+VERSION = (0, 5, 0)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 4, 4)
+VERSION = (0, 4, 5)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 6, 0)
+VERSION = (0, 6, 1)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 5, 0)
+VERSION = (0, 5, 1)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/control.py
+++ b/src/gui_executor/control.py
@@ -11,7 +11,7 @@ class Control:
 
         modules = self._model.get_ui_modules()
 
-        for _, mod in modules.items():
+        for _, mod in sorted(modules.values()):
             try:
                 funcs = self._model.get_ui_buttons_functions(mod)
 

--- a/src/gui_executor/model.py
+++ b/src/gui_executor/model.py
@@ -1,3 +1,5 @@
+import contextlib
+import importlib
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -17,4 +19,10 @@ class Model:
         return find_ui_button_functions(mod)
 
     def get_ui_modules(self) -> Dict[str, Any]:
-        return find_modules(self._module_path)
+        response = {}
+        for name, path in find_modules(self._module_path).items():
+            with contextlib.suppress(ModuleNotFoundError):
+                mod = importlib.import_module(path)
+                display_name = getattr(mod, "UI_MODULE_DISPLAY_NAME", name)
+                response[name] = (display_name, path)
+        return response

--- a/src/gui_executor/view.py
+++ b/src/gui_executor/view.py
@@ -4,6 +4,7 @@ import ast
 import contextlib
 import errno
 import fcntl
+import inspect
 import os
 import queue
 import select
@@ -651,7 +652,7 @@ class ArgumentsPanel(QScrollArea):
                 input_field.setCheckState(Qt.Checked if arg.default else Qt.Unchecked)
             elif isinstance(arg.annotation, TypeObject):
                 input_field: QWidget = arg.annotation.get_widget()
-            elif issubclass(arg.annotation, Enum):
+            elif inspect.isclass(arg.annotation) and issubclass(arg.annotation, Enum):
                 input_field = combo_box_from_enum(arg.annotation)
             else:
                 input_field = QLineEdit()
@@ -796,7 +797,7 @@ class ArgumentsPanel(QScrollArea):
             return field.checkState() == Qt.Checked
         elif isinstance(arg.annotation, TypeObject):
             return field.get_value()
-        elif issubclass(arg.annotation, Enum):
+        elif inspect.isclass(arg.annotation) and issubclass(arg.annotation, Enum):
             return arg.annotation[field.currentText()]
         else:
 

--- a/src/gui_executor/view.py
+++ b/src/gui_executor/view.py
@@ -19,6 +19,7 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
+import distro as distro
 from PyQt5.QtCore import QObject
 from PyQt5.QtCore import QProcess
 from PyQt5.QtCore import QRunnable
@@ -407,7 +408,7 @@ class ConsoleOutput(QTextEdit):
         self.setMinimumSize(600, 100)
         monospaced_font = QFont("Courier New")
         monospaced_font.setStyleHint(QFont.Monospace)
-        monospaced_font.setPointSize(14)  # TODO: should be a setting
+        monospaced_font.setPointSize(12)  # TODO: should be a setting
         self.setFont(monospaced_font)
 
         self.setContextMenuPolicy(Qt.CustomContextMenu)
@@ -581,7 +582,7 @@ class DynamicButton(QWidget):
 
         # The following line will put the display_name within triangles: ▶︎ name ◀︎
         # when the immediate_run flag is True
-        name = f"\u25B6 {name} \u25C0" if self._function.__ui_immediate_run__ else name
+        # name = f"\u25B6 {name} \u25C0" if self._function.__ui_immediate_run__ else name
 
         return name
 
@@ -601,6 +602,9 @@ class ArgumentsPanel(QScrollArea):
         super().__init__()
 
         self.setWidgetResizable(True)
+
+        widget = QWidget()
+        main_layout = QHBoxLayout()
 
         self.group_box = QGroupBox(f"arguments for '{button.function_display_name}'")
         self.group_box.setStyleSheet(
@@ -719,7 +723,9 @@ class ArgumentsPanel(QScrollArea):
         vbox.addLayout(hbox)
 
         self.group_box.setLayout(vbox)
-        self.setWidget(self.group_box)
+        main_layout.addWidget(self.group_box)
+        widget.setLayout(main_layout)
+        self.setWidget(widget)
 
         # self.setStyleSheet("border:1px solid rgb(0, 0, 0); ")
 
@@ -802,6 +808,24 @@ class FunctionButtonsPanel(QScrollArea):
 
         widget = QWidget()
 
+        widget.setStyleSheet(textwrap.dedent(
+            """
+                QGroupBox {
+                    font-size: 16px;
+                    font-weight: light;
+                    color: grey;
+                    /* margin-top: 25px; */
+                }
+                QGroupBox::title {
+                    subcontrol-origin: margin;
+                    subcontrol-position: top left;
+                    left: 10px;
+                    /* padding-top: 5px; */
+                    /* padding-bottom: 0px */
+                }
+            """)
+        )
+
         self.n_cols = 4  # This must be a setting or configuration option
 
         # The modules are arranged in a vertical layout and each of the functions in that module is arranged in a
@@ -810,7 +834,8 @@ class FunctionButtonsPanel(QScrollArea):
         self.modules: Dict[str, QGridLayout] = {}
         self.buttons: Dict[str, int] = {}
         self.module_layout = QVBoxLayout()
-        self.module_layout.setSpacing(25)
+        self.module_layout.setSpacing(10 if distro.id().lower() == 'ubuntu' else 25)
+        self.module_layout.addStretch(1)
 
         widget.setLayout(self.module_layout)
 
@@ -826,22 +851,9 @@ class FunctionButtonsPanel(QScrollArea):
                 grid.setColumnStretch(idx, 1)
             gbox = QGroupBox(display_name)
             gbox.setLayout(grid)
-            gbox.setStyleSheet(textwrap.dedent("""
-                QGroupBox {
-                    font-size: 16px;
-                    font-weight: light;
-                    color: grey;
-                    margin-top: 25px;
-                }
-                QGroupBox::title {
-                    subcontrol-origin: margin;
-                    left: 10px;
-                    padding-top: 5px;
-                    padding-bottom: 0px
-                }
-            """))
             gbox.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
-            self.module_layout.addWidget(gbox)
+            # self.module_layout.addWidget(gbox)
+            self.module_layout.insertWidget(self.module_layout.count()-1, gbox)
             self.modules[module_name] = grid
             self.buttons[module_name] = 0
 

--- a/src/gui_executor/view.py
+++ b/src/gui_executor/view.py
@@ -517,6 +517,16 @@ class DynamicButton(QWidget):
 
         self.label_icon = IconLabel(icon_path=self.icon_path, size=icon_size)
         label_text = QLabel(self.function_display_name)
+        if self._function.__ui_immediate_run__:
+            # This style will draw a 2 pixel horizontal line under the label
+            label_text.setStyleSheet(textwrap.dedent(
+                """\
+                    padding-bottom: 0px; 
+                    border-bottom-width: 2px; 
+                    border-bottom-style: solid; 
+                    border-radius: 0px;
+                """)
+            )
 
         layout.addWidget(self.label_icon)
         layout.addSpacing(self.horizontal_spacing)
@@ -565,7 +575,13 @@ class DynamicButton(QWidget):
 
     @property
     def function_display_name(self) -> str:
-        return self._function.__ui_display_name__ or self.label or self._function.__name__
+        name = self._function.__ui_display_name__ or self.label or self._function.__name__
+
+        # The following line will put the display_name within triangles: ▶︎ name ◀︎
+        # when the immediate_run flag is True
+        # name = f"\u25B6 {name} \u25C0" if self._function.__ui_immediate_run__ else name
+
+        return name
 
     @property
     def label(self) -> str:

--- a/src/gui_executor/view.py
+++ b/src/gui_executor/view.py
@@ -604,26 +604,28 @@ class ArgumentsPanel(QScrollArea):
         self.setWidgetResizable(True)
 
         widget = QWidget()
+
+        widget.setStyleSheet(textwrap.dedent(
+            """
+                QGroupBox {
+                    font-size: 16px;
+                    font-weight: light;
+                    color: grey;
+                    /* margin-top: 25px; */
+                }
+                QGroupBox::title {
+                    subcontrol-origin: margin;
+                    subcontrol-position: top left;
+                    left: 10px;
+                    /* padding-top: 5px; */
+                    /* padding-bottom: 0px */
+                }
+            """)
+        )
+
         main_layout = QHBoxLayout()
 
         self.group_box = QGroupBox(f"arguments for '{button.function_display_name}'")
-        self.group_box.setStyleSheet(
-            textwrap.dedent(
-                """
-                    QGroupBox {
-                        font-size: 14px;
-                        font-weight: light;
-                        color: grey;
-                        margin-top: 25px;
-                    }
-                    QGroupBox::title {
-                        subcontrol-origin: margin;
-                        left: 10px;
-                        padding-top: 5px;
-                        padding-bottom: 0px
-                    }
-                """)
-        )
 
         self._button = button
         self._ui_args = ui_args

--- a/src/gui_executor/view.py
+++ b/src/gui_executor/view.py
@@ -522,9 +522,9 @@ class DynamicButton(QWidget):
             label_text.setStyleSheet(textwrap.dedent(
                 """\
                     padding: 0px; 
-                    border-bottom-width: 1px; 
+                    border-bottom-width: 0px;  /* set to 1 or 2 if you need a bottom line */
                     border-bottom-style: solid; 
-                    border-bottom-color: blue; 
+                    border-bottom-color: blue;
                     border-radius: 0px;
                     color: blue;
                 """)
@@ -581,7 +581,7 @@ class DynamicButton(QWidget):
 
         # The following line will put the display_name within triangles: ▶︎ name ◀︎
         # when the immediate_run flag is True
-        # name = f"\u25B6 {name} \u25C0" if self._function.__ui_immediate_run__ else name
+        name = f"\u25B6 {name} \u25C0" if self._function.__ui_immediate_run__ else name
 
         return name
 

--- a/src/gui_executor/view.py
+++ b/src/gui_executor/view.py
@@ -838,6 +838,7 @@ class FunctionButtonsPanel(QScrollArea):
                     padding-bottom: 0px
                 }
             """))
+            gbox.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
             self.module_layout.addWidget(gbox)
             self.modules[module_name] = grid
             self.buttons[module_name] = 0

--- a/src/gui_executor/view.py
+++ b/src/gui_executor/view.py
@@ -732,6 +732,7 @@ class ArgumentsPanel(QScrollArea):
         hbox.addStretch()
         hbox.addWidget(self.run_button)
 
+        vbox.addStretch()
         vbox.addLayout(hbox)
 
         self.group_box.setLayout(vbox)

--- a/src/gui_executor/view.py
+++ b/src/gui_executor/view.py
@@ -521,10 +521,12 @@ class DynamicButton(QWidget):
             # This style will draw a 2 pixel horizontal line under the label
             label_text.setStyleSheet(textwrap.dedent(
                 """\
-                    padding-bottom: 0px; 
-                    border-bottom-width: 2px; 
+                    padding: 0px; 
+                    border-bottom-width: 1px; 
                     border-bottom-style: solid; 
+                    border-bottom-color: blue; 
                     border-radius: 0px;
+                    color: blue;
                 """)
             )
 

--- a/tests/contingency/ui_enum_arguments.py
+++ b/tests/contingency/ui_enum_arguments.py
@@ -1,0 +1,41 @@
+from enum import IntEnum
+
+from gui_executor.exec import exec_ui
+
+UI_MODULE_DISPLAY_NAME = "01 Enum Arguments"
+
+
+class Digit(IntEnum):
+    ZERO = 0
+    ONE = 1
+    TWO = 2
+    THREE = 3
+    FOUR = 4
+    FIVE = 5
+    SIX = 6
+    SEVEN = 7
+    EIGHT = 8
+    NINE = 9
+
+
+class OperatingMode(IntEnum):
+    STANDBY = 0
+    SELFTEST = 1
+    ALIGNMENT = 2
+    FC_TVAC = 3
+
+
+@exec_ui()
+def name_of(digit: Digit):
+    print(f"{digit.value} -> {digit.name}")
+
+
+@exec_ui()
+def value_of(digit: Digit):
+    print(f"{digit.name} = {digit.value}")
+
+
+@exec_ui()
+def select_operating_mode(mode: OperatingMode):
+
+    print(f"{mode.name} = {mode.value} \[{mode=}]")

--- a/tests/tasks/first_row.py
+++ b/tests/tasks/first_row.py
@@ -1,5 +1,7 @@
 from gui_executor.exec import exec_ui
 
+UI_MODULE_DISPLAY_NAME = "First Row of Tasks"
+
 
 @exec_ui(immediate_run=True)
 def immediate_run():

--- a/tests/tasks/second_row.py
+++ b/tests/tasks/second_row.py
@@ -1,0 +1,10 @@
+from gui_executor.exec import exec_ui
+
+UI_MODULE_DISPLAY_NAME = "Second Row of Tasks"
+
+
+@exec_ui()
+def print_sys_path():
+    import sys
+
+    print(sys.path)

--- a/tests/tasks/simple.py
+++ b/tests/tasks/simple.py
@@ -1,0 +1,6 @@
+from gui_executor.exec import exec_ui
+
+
+@exec_ui(immediate_run=True)
+def immediate_run():
+    print("[blue]The task has run successfully[/]")


### PR DESCRIPTION
* implemented immediate_run buttons which will execute immediately when pressed. These buttons do not take arguments and you have to specify the run type in the `exec_ui` decorator. The immediate_run buttons are marked in blue.
* fixed some layout problems
* modules are now sorted by their display name
* implemented Enum as a recognised type hint and the arguments panel will create a ComboBox to specify the value