### PR TITLE
fix support for str, enum, and make non-modal dialog, fix duplicate traceback output

### DIFF
--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 9, 4)
+VERSION = (0, 9, 5)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 9, 5)
+VERSION = (0, 9, 6)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 9, 3)
+VERSION = (0, 9, 4)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/utils.py
+++ b/src/gui_executor/utils.py
@@ -188,7 +188,8 @@ def custom_repr(arg: Any):
     if not isinstance(arg, Enum):
         return repr(arg)
 
-    m = re.fullmatch(r"<([\w.]+): (\d+)>", repr(arg))
+    m = re.fullmatch(r"<([\w.]+): (.*)>", repr(arg))
+
     return m[1]
 
 

--- a/tests/contingency/ui_enum_arguments.py
+++ b/tests/contingency/ui_enum_arguments.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from enum import IntEnum
 
 from gui_executor.exec import exec_ui
@@ -23,6 +24,17 @@ class OperatingMode(IntEnum):
     SELFTEST = 1
     ALIGNMENT = 2
     FC_TVAC = 3
+
+
+class CSLSiteId(str, Enum):
+    CSL = "CSL"
+    CSL1 = "CSL1"
+    CSL2 = "CSL2"
+
+
+@exec_ui()
+def str_enum(csl_site: CSLSiteId = CSLSiteId.CSL, setup_id: int = 98):
+    print(f"{csl_site=}, {setup_id=}")
 
 
 @exec_ui()


### PR DESCRIPTION
This PR fixes issue #6 which crashed on classes the are `str`, `Enum`. The regex was improved to cope with other types of Enum.

A test task str_enum() was added in the `test/contingency/ui_enum_arguments.py` to demonstrate the fix (see screenshot).

<img width="712" alt="image" src="https://user-images.githubusercontent.com/6662864/191364031-d94fb3fb-204a-498c-8b69-f39eb87d617a.png">


I should start using branches on this repo to not mix pull requests...

Additionally, I have pushed a fix for #10 and #11.
