### PR TITLE
implemented default value for callbacks and Enum types

### DIFF
--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 12, 1)
+VERSION = (0, 12, 2)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/utils.py
+++ b/src/gui_executor/utils.py
@@ -273,13 +273,13 @@ def select_file(filename: str = None, full_path: bool = True) -> str:
     return filenames[0] if filenames is not None else ''
 
 
-def combo_box_from_enum(enumeration: Enum):
+def combo_box_from_enum(enumeration: Enum) -> QComboBox:
     cb = QComboBox()
     cb.addItems([x.name for x in enumeration])
     return cb
 
 
-def combo_box_from_list(values: List):
+def combo_box_from_list(values: List) -> QComboBox:
     cb = QComboBox()
     cb.addItems(str(x) for x in values)
     return cb

--- a/src/gui_executor/utypes.py
+++ b/src/gui_executor/utypes.py
@@ -49,16 +49,17 @@ class UQWidget(QWidget):
 
 
 class Callback(TypeObject):
-    def __init__(self, func: Callable, name: str = None):
+    def __init__(self, func: Callable, default: Callable = None, name: str = None):
         super().__init__(name=name)
         self.func = func
+        self.default_func = default
 
     def get_widget(self):
-        return CallbackWidget(self.func)
+        return CallbackWidget(self.func, self.default_func)
 
 
 class CallbackWidget(UQWidget):
-    def __init__(self, func: Callable):
+    def __init__(self, func: Callable, default_func: Callable):
         super().__init__()
 
         hbox = QHBoxLayout()
@@ -68,9 +69,13 @@ class CallbackWidget(UQWidget):
         self.func_rc = func()
 
         if isinstance(self.func_rc, (list, tuple)):
-            self.widget = combo_box_from_list(self.func_rc)
+            self.widget:QComboBox = combo_box_from_list(self.func_rc)
+            if default_func is not None:
+                self.widget.setCurrentText(str(default_func()))
         elif inspect.isclass(self.func_rc) and issubclass(self.func_rc, Enum):
-            self.widget = combo_box_from_enum(self.func_rc)
+            self.widget: QComboBox = combo_box_from_enum(self.func_rc)
+            if default_func is not None:
+                self.widget.setCurrentText(default_func().name)
         else:
             self.widget = QLineEdit()
             self.widget.setPlaceholderText(str(self.func_rc))

--- a/src/gui_executor/view.py
+++ b/src/gui_executor/view.py
@@ -773,7 +773,9 @@ class ArgumentsPanel(QScrollArea):
             elif isinstance(arg.annotation, (TypeObject, Callback)):
                 input_field: QWidget = arg.annotation.get_widget()
             elif inspect.isclass(arg.annotation) and issubclass(arg.annotation, Enum):
-                input_field = combo_box_from_enum(arg.annotation)
+                input_field: QComboBox = combo_box_from_enum(arg.annotation)
+                if arg.default is not None:
+                    input_field.setCurrentText(arg.default.name)
             else:
                 input_field = QLineEdit()
                 input_field.setObjectName(name)

--- a/tests/contingency/ui_callback_arguments.py
+++ b/tests/contingency/ui_callback_arguments.py
@@ -38,11 +38,19 @@ def random_callback(word: Callback(random_word, name="str")):
     print(f"A random word: {word}")
 
 
+def default_digit() -> Digit:
+    return Digit.EIGHT
+
+
 @exec_ui()
-def enum_callback(digit: Callback(int_enum, name="int")):
+def enum_callback(digit: Callback(int_enum, name="int", default=default_digit)):
     print(f"You selected {digit}")
 
 
+def default_float() -> float:
+    return 0.5
+
+
 @exec_ui()
-def list_callback(number: Callback(list_of_floats, name="float")):
+def list_callback(number: Callback(list_of_floats, name="float", default=default_float)):
     print(f"You selected {number}")

--- a/tests/contingency/ui_enum_arguments.py
+++ b/tests/contingency/ui_enum_arguments.py
@@ -33,7 +33,7 @@ class CSLSiteId(str, Enum):
 
 
 @exec_ui()
-def str_enum(csl_site: CSLSiteId = CSLSiteId.CSL, setup_id: int = 98):
+def str_enum(csl_site: CSLSiteId = CSLSiteId.CSL2, setup_id: int = 98):
     print(f"{csl_site=}, {setup_id=}")
 
 
@@ -43,7 +43,7 @@ def name_of(digit: Digit):
 
 
 @exec_ui()
-def value_of(digit: Digit):
+def value_of(digit: Digit = Digit.FIVE):
     print(f"{digit.name} = {digit.value}")
 
 


### PR DESCRIPTION
The default value that is provided when the argument of the task is an Enum, is now taken into account.

The Callback TypeObject now accepts a default kwarg which should be a Callable that returns the required default value to be used.