### PR TITLE
Implement the possibility to re-use functions in different TABs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,7 @@ This page will keep track of the features that we plan to implement in the futur
 
 GUI
   - [x] Allow sub-packages with their own task groups and organise them in TABs task view
+  - [x] Provide functionality to re-use tasks in other TABs and organised under different groups
   - [ ] Implement dark mode
   - [ ] There shall be a Preferences dailog to tune the behaviour of the GUI, e.g. toggle dark mode, set default timeout interval for recurring tasks, ....
   

--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 15, 2)
+VERSION = (0, 16, 0)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 16, 0)
+VERSION = (0, 16, 1)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/utils.py
+++ b/src/gui_executor/utils.py
@@ -97,15 +97,20 @@ def get_file_path(path: str | Path, name: str) -> Path:
     return filepath
 
 
-def copy_func(func, display_name=None):
+def copy_func(func, module_display_name=None, function_display_name=None):
     """
     Returns a deep copy of a function object. All function attributes that start with '__ui' are also copied.
     These attributes are used internally by the 'gui-executor'. Provide display_name if you want to connect
     the returned function to a module with that display name. The latter is used to organised functions in a TAB.
 
+    Note: use the function with caution. Especially, specifying a function_display_name will lose the connection
+          with the original function for the user and might be very confusing. Only specify the function_display_name
+          when you know what you are doing and what the impact is for the user.
+
     Args:
         func: a function object
-        display_name: the name of a module/group to be used
+        module_display_name: the name of a module/group to be used to display
+        function_display_name: name of function to be used to display
 
     Returns:
         A deep copy of the given function object.
@@ -120,8 +125,11 @@ def copy_func(func, display_name=None):
         if ui_attr.startswith("__ui"):
             setattr(new_func, ui_attr, getattr(func, ui_attr))
 
-    if display_name:
-        new_func.__ui_module_display_name__ = display_name
+    if module_display_name:
+        new_func.__ui_module_display_name__ = module_display_name
+
+    if function_display_name:
+        new_func.__ui_display_name__ = function_display_name
 
     return new_func
 

--- a/src/gui_executor/view.py
+++ b/src/gui_executor/view.py
@@ -746,7 +746,12 @@ class DynamicButton(QWidget):
     @property
     def module_display_name(self) -> str:
         try:
-            return sys.modules[self._function.__ui_module__].UI_MODULE_DISPLAY_NAME
+            try:
+                # This attribute is given to the function when copying the function object
+                # to be used in a different TAB with another display name
+                return self._function.__ui_module_display_name__
+            except AttributeError:
+                return sys.modules[self._function.__ui_module__].UI_MODULE_DISPLAY_NAME
         except (AttributeError, KeyError):
             return self.module_name.rsplit(".", 1)[-1]
 
@@ -1028,14 +1033,13 @@ class FunctionButtonsPanel(QScrollArea):
         self.setWidget(widget)
 
     def add_button(self, button: DynamicButton):
-        module_name = button.module_name
+        module_name = button.module_display_name
         if module_name not in self.modules:
-            display_name = button.module_display_name
             grid = QGridLayout()
             # Make sure all columns have equal width
             for idx in range(self.n_cols):
                 grid.setColumnStretch(idx, 1)
-            gbox = QGroupBox(display_name)
+            gbox = QGroupBox(module_name)
             gbox.setLayout(grid)
             gbox.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
             # self.module_layout.addWidget(gbox)

--- a/tests/tasks/specific/__init__.py
+++ b/tests/tasks/specific/__init__.py
@@ -1,1 +1,1 @@
-UI_TAB_ORDER = ['second_tab', 'first_tab', 'third_tab']
+UI_TAB_ORDER = ['virtual', 'second_tab', 'first_tab', 'third_tab']

--- a/tests/tasks/specific/first_tab/sys_path.py
+++ b/tests/tasks/specific/first_tab/sys_path.py
@@ -5,3 +5,9 @@ from gui_executor.exec import exec_task
 def print_sys_path():
     import sys
     print(sys.path)
+
+
+@exec_task(immediate_run=True)
+def print_sys_version():
+    import sys
+    print(sys.version)

--- a/tests/tasks/specific/third_tab/second_row.py
+++ b/tests/tasks/specific/third_tab/second_row.py
@@ -1,4 +1,7 @@
 from gui_executor.exec import exec_ui
+from gui_executor.utils import copy_func
+
+from tasks.specific.second_tab.print_this import print_this
 
 UI_MODULE_DISPLAY_NAME = "Second Row of Tasks"
 
@@ -6,3 +9,6 @@ UI_MODULE_DISPLAY_NAME = "Second Row of Tasks"
 @exec_ui()
 def print_args(name: str = "Rik Huygen", nick_name: str = "Rik"):
     print(f"{name = }, {nick_name = }")
+
+
+print_this = copy_func(print_this, UI_MODULE_DISPLAY_NAME)

--- a/tests/tasks/specific/virtual/__init__.py
+++ b/tests/tasks/specific/virtual/__init__.py
@@ -1,0 +1,1 @@
+UI_TAB_DISPLAY_NAME = "Virtual"

--- a/tests/tasks/specific/virtual/tasks.py
+++ b/tests/tasks/specific/virtual/tasks.py
@@ -1,0 +1,23 @@
+from gui_executor.utils import copy_func
+
+# Import all the tasks that you want to gather in this TAB
+
+from tasks.specific.first_tab.sys_path import print_sys_version
+from tasks.specific.first_tab.sys_path import print_sys_path
+from tasks.specific.second_tab.print_this import print_this
+from tasks.specific.third_tab.second_row import print_args
+from tasks.specific.third_tab.first_row import immediate_run, immediate_run_kernel
+
+# Make sure all imported tasks are copied and named
+
+name = "Print Functions"
+
+print_sys_version = copy_func(print_sys_version, name)
+print_sys_path = copy_func(print_sys_path, name)
+print_this = copy_func(print_this, name)
+print_args = copy_func(print_args, name)
+
+name = "Immediate Functions"
+
+immediate_run = copy_func(immediate_run, name)
+immediate_run_kernel = copy_func(immediate_run_kernel, name)

--- a/tests/tasks/specific/virtual/tasks.py
+++ b/tests/tasks/specific/virtual/tasks.py
@@ -14,7 +14,7 @@ name = "Print Functions"
 
 print_sys_version = copy_func(print_sys_version, name)
 print_sys_path = copy_func(print_sys_path, name)
-print_this = copy_func(print_this, name)
+print_this = copy_func(print_this, name, "Import this")
 print_args = copy_func(print_args, name)
 
 name = "Immediate Functions"


### PR DESCRIPTION
You might want to re-use some of your tasks in another TAB for quick access of e.g. status tasks or contingency tasks. Instead of copying task code, you can now import the task in another module and use the `copy_func()` function to create a copy of the task (function object) with a different module display name.