### PR TITLE
provide TextInputField which is a QLineEdit with handling of defaults and placeholders

### DIFF
--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 17, 0)
+VERSION = (0, 17, 1)
 
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
In the text input fields, we now have a small icon align right in the field. Pressing this icon will fill the default value into the text field. Alternatively, you can use the context menu which has a _Set default_.