### PR TITLE
Implemented capture_response as a decorator parameter

### DIFF
--- a/docs/gui-executor.adoc
+++ b/docs/gui-executor.adoc
@@ -184,6 +184,26 @@ TBW
 * ListList
 * Callback
 
+=== Capture the result
+
+Since the task that is executed by the GUI is in fact a simple function, it can also return results. These results are normally captured in a variable `response` which is overwritten by new values each time a task is executed from the GUI, even if the task doesn't return anything explicitly in which case response will be None.
+
+The developer of the task can decide to capture the result of a task in a different variable or set of variables. This can be specified in the decorator parameter `capture_response` which can be a string or a tuple of strings. See an example below. The task `generate_model` returns three values of which we only need the 'model' and the 'hexhw'. In the `capture_response` you see that the second unused return value is captured in the `\_` and therefore ignored. If you need to ignore more return values, the `*_` is a valid choice.
+
+----
+@exec_task(capture_response=("model", "_", "hexhw"))
+def generate_model():
+    model = "This is a model"
+    s = "an unused return value..."
+    hexhw = "this is a reference to a hardware device"
+    return model, s, hexhw
+----
+
+Notice that the `capture_response` represents what you would actually write in your Python script when calling the function directly.
+----
+>>> model, _, hexhw = generate_model()
+----
+
 === Choosing your icons
 
 TBW

--- a/src/gui_executor/__version__.py
+++ b/src/gui_executor/__version__.py
@@ -1,6 +1,6 @@
 """
 The one and only place for the version number.
 """
-VERSION = (0, 17, 2)
+VERSION = (0, 18, 0)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/gui_executor/exec.py
+++ b/src/gui_executor/exec.py
@@ -100,6 +100,7 @@ def exec_ui(
         icons: Tuple[str | Path, ...] = None,
         immediate_run: bool = False,
         allow_kernel_interrupt: bool = False,
+        capture_response: str | tuple[str, ...] = "response",
 ):
     """
     Decorates the function as an Exec UI function. We have different kinds of UI functions. By default,
@@ -116,6 +117,8 @@ def exec_ui(
         icons: icons to be used for the button of this function
         immediate_run: when True execute the function immediately when pressed without creating and
             presenting the arguments panel with the Run button
+        allow_kernel_interrupt: allow this GUI to interrupt the kernel before running this task
+        capture_response: replace the response to capture return values in different variables
 
     Returns:
         The wrapper function object.
@@ -136,6 +139,7 @@ def exec_ui(
         wrapper.__ui_immediate_run__ = immediate_run
         wrapper.__ui_icons__ = icons
         wrapper.__ui_allow_kernel_interrupt__ = allow_kernel_interrupt
+        wrapper.__ui_capture_response__ = capture_response if isinstance(capture_response, str) else ", ".join(capture_response)
         if use_script_app:
             wrapper.__ui_runnable__ = RUNNABLE_SCRIPT
         elif use_kernel:

--- a/src/gui_executor/utils.py
+++ b/src/gui_executor/utils.py
@@ -274,14 +274,14 @@ def create_code_snippet(func: Callable, args: List, kwargs: Dict, call_func: boo
                     print(response)
                 return response
                     
-            {"response = main()" if call_func else ''}
+            {f"{func.__ui_capture_response__} = main()" if call_func else ''}
         """
     )
 
 
 def create_code_snippet_renderable(func: Callable, args: List, kwargs: Dict):
 
-    snippet = f"response = {func.__name__}({stringify_args(args)}{', ' if args else ''}{stringify_kwargs(kwargs)})"
+    snippet = f"{func.__ui_capture_response__} = {func.__name__}({stringify_args(args)}{', ' if args else ''}{stringify_kwargs(kwargs)})"
 
     return Panel(Syntax(snippet, "python", theme='default', word_wrap=True), box=box.HORIZONTALS)
 

--- a/src/gui_executor/view.py
+++ b/src/gui_executor/view.py
@@ -943,6 +943,7 @@ class ArgumentsPanel(QScrollArea):
                 grid.addWidget(type_hint, idx, 2, alignment=Qt.AlignVCenter)
 
         vbox.addLayout(grid)
+        vbox.addWidget(QLabel(f"Return value(s) will be captured in and overwrite '{self.function.__ui_capture_response__}'."))
 
         hbox = QHBoxLayout()
         button_group = QButtonGroup()

--- a/tests/tasks/shared/unit_tests/ui_response.py
+++ b/tests/tasks/shared/unit_tests/ui_response.py
@@ -1,0 +1,29 @@
+from typing import Tuple
+
+from gui_executor.exec import exec_task, FileName, FilePath, Directory
+
+UI_MODULE_DISPLAY_NAME = "Capture Responses"
+
+
+@exec_task()
+def return_a_float(value: float = 0.0) -> float:
+    return value
+
+
+@exec_task(capture_response=("idx", "val"))
+def return_int_and_float(idx: int = 0, value: float = 0.0) -> Tuple[int, float]:
+    """
+    Function that returns its arguments. This tasks is to showcase the possibility for the developer
+    to specify variable names for return values. The values returned by the function will then be
+    captured in these variables and will be available in the kernel after the task has run.
+    If the developer didn't specify any variable names, the returned values will be captured in the
+    variable 'response'.
+
+    Args:
+        idx: an integer number
+        value:  a floating point number
+
+    Returns:
+        The tuple (idx, val) with the given values from the arguments.
+    """
+    return idx, value

--- a/tests/tasks/shared/unit_tests/ui_response.py
+++ b/tests/tasks/shared/unit_tests/ui_response.py
@@ -27,3 +27,11 @@ def return_int_and_float(idx: int = 0, value: float = 0.0) -> Tuple[int, float]:
         The tuple (idx, val) with the given values from the arguments.
     """
     return idx, value
+
+
+@exec_task(capture_response=("model", "_", "hexhw"))
+def generate_model():
+    model = "This is a model"
+    s = "an unused return value..."
+    hexhw = "this is a reference to a hardware device"
+    return model, s, hexhw


### PR DESCRIPTION
The capture_response parameter for the exec_task decorator allows the developer of the task to specify variable names in which the response of the task shall be captured. See the documentation for more information.